### PR TITLE
Pin `action-setup-thrift` to v0.0.4 in Erlang actions

### DIFF
--- a/.github/workflows/erlang-pr.yml
+++ b/.github/workflows/erlang-pr.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: valitydev/action-setup-thrift@v0
+      - uses: valitydev/action-setup-thrift@v0.0.4
         with:
           thrift-version: '0.14.2'
 

--- a/.github/workflows/erlang-pr.yml
+++ b/.github/workflows/erlang-pr.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: valitydev/action-setup-thrift@b457b89c7e1e960ea354f510bce69a725d16c556
+      - uses: valitydev/action-setup-thrift@v0
         with:
           thrift-version: '0.14.2'
 


### PR DESCRIPTION
Instead of commit hash.