### PR TITLE
INT-41: Bump woody version

### DIFF
--- a/.github/workflows/deploy-jar.yml
+++ b/.github/workflows/deploy-jar.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Install thrift
-        uses: valitydev/action-setup-thrift@v0.0.4
+        uses: valitydev/action-setup-thrift@v0.0.5
       - name: Checkout Repo
         uses: actions/checkout@v2
         with:
@@ -22,7 +22,7 @@ jobs:
           echo "::set-output name=SHA_7::${GITHUB_SHA::7}"
         id: commit_info
       - name: Deploy package
-        uses: valitydev/action-deploy-jdk-package@v1.0.12
+        uses: valitydev/action-deploy-jdk-package@v1.0.13
         with:
           server-username: ${{ secrets.OSSRH_USERNAME }}
           server-password: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/erlang-pr.yml
+++ b/.github/workflows/erlang-pr.yml
@@ -14,8 +14,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: valitydev/action-setup-thrift@v0.0.5
-        with:
-          thrift-version: '0.14.2'
 
       - uses: erlef/setup-beam@v1.10
         id: beam

--- a/.github/workflows/erlang-pr.yml
+++ b/.github/workflows/erlang-pr.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: valitydev/action-setup-thrift@v0.0.4
+      - uses: valitydev/action-setup-thrift@v0.0.5
         with:
           thrift-version: '0.14.2'
 

--- a/.github/workflows/java-pr.yml
+++ b/.github/workflows/java-pr.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Install thrift
-        uses: valitydev/action-setup-thrift@v0.0.4
+        uses: valitydev/action-setup-thrift@v0.0.5
       - name: Checkout Repo
         uses: actions/checkout@v2
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.vality</groupId>
         <artifactId>library-parent-pom</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
     </parent>
 
     <artifactId>damsel</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>dev.vality.woody</groupId>
             <artifactId>woody-thrift</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Необходимо обновить версию woody после внесения изменений в протокол (были восстановлены ранее удаленные интерфейсы):
https://github.com/valitydev/woody_java/commit/378529478f4a14ce71984f65df841d409f2c29e1
https://github.com/valitydev/woody_java/commit/6c2e819e799beaec12077f26f4bc04fecd4b9a10
https://github.com/valitydev/woody_java/commit/bad5e754af256640d94575287d6167c181393b56

