### PR TITLE
APM-52: Introduce `GenericPaymentMethod` and related models

### DIFF
--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -1739,10 +1739,12 @@ union PaymentMethod {
     7: LegacyMobileOperator mobile_deprecated
 }
 
-typedef string GenericPaymentMethodID
-
 struct GenericPaymentMethod {
-    1: required GenericPaymentMethodID id
+    /**
+     * Сервис, обслуживающий данный платёжный инструмент.
+     * Например: `{"id": "BankTransfersRUS"}`
+     */
+    1: required PaymentServiceRef payment_service
 }
 
 struct BankCardPaymentMethod {
@@ -1832,13 +1834,11 @@ union PaymentTool {
 
 struct GenericPaymentTool {
 
-    1: required GenericPaymentMethodID method
-
     /**
      * Сервис, обслуживающий данный платёжный инструмент.
-     * На данный момент соответствует значению, указанному в `PaymentMethodDefinition`.
+     * Должен соответствовать значению, указанному в `GenericPaymentMethod`.
      */
-    2: optional PaymentServiceRef provider
+    1: required PaymentServiceRef payment_service
 
     /**
      * Данные платёжного инструмента, определённые в соответствии со схемой в
@@ -1851,7 +1851,7 @@ struct GenericPaymentTool {
      * }
      * ```
      */
-    3: optional base.Content data
+    2: optional base.Content data
 
 }
 
@@ -2102,32 +2102,6 @@ struct PaymentMethodRef { 1: required PaymentMethod id }
 struct PaymentMethodDefinition {
     1: required string name
     2: required string description
-
-    /**
-     * Категория платёжных инструментов.
-     * Например: `online-banking`.
-     * Открытое множество, конкретные значения согласовываются:
-     *  - на уровне констант в протоколе,
-     *  - вне протокола, на уровне конкретных интеграций.
-     * 
-     * Категория, заданная на уровне `PaymentService` по идее должна быть
-     * упразднена в пользу значения, задаваемого здесь.
-     */
-    3: optional PaymentServiceCategory category
-
-    /**
-     * Сервис, обслуживающий любые инструменты платежа с этим методом.
-     */
-    4: optional PaymentServiceRef provider
-
-    /**
-     * Схема данных любого платёжного инструмента в рамках данного метода.
-     * Соответствующие этой схеме данные платёжного инструмента попадают в
-     * поле `data` модели `GenericPaymentTool`.
-     * Важно: должно быть задано для методов, определённых как `GenericPaymentMethod`.
-     */
-    5: optional PaymentMethodSchema schema
-
 }
 
 union PaymentMethodSchema {
@@ -2781,9 +2755,7 @@ union PaymentToolCondition {
     2: PaymentTerminalCondition payment_terminal
     4: CryptoCurrencyCondition crypto_currency
     5: MobileCommerceCondition mobile_commerce
-    // generic conditions
-    6: GenericPaymentMethod payment_method_is
-    7: PaymentServiceRef payment_service_is
+    6: GenericPaymentToolCondition generic
 }
 
 struct BankCardCondition {
@@ -2847,6 +2819,10 @@ union MobileCommerceConditionDefinition {
     2: MobileOperatorRef operator_is
     /** Deprecated **/
     1: LegacyMobileOperator operator_is_deprecated
+}
+
+union GenericPaymentToolCondition {
+    1: PaymentServiceRef payment_service_is
 }
 
 struct PartyCondition {

--- a/proto/payment_tool_token.thrift
+++ b/proto/payment_tool_token.thrift
@@ -18,11 +18,16 @@ struct PaymentToolToken {
     Данные платежного токена
 */
 union PaymentToolTokenPayload {
+    6: GenericToolPayload generic_payload
     1: BankCardPayload bank_card_payload
     2: PaymentTerminalPayload payment_terminal_payload
     3: DigitalWalletPayload digital_wallet_payload
     4: CryptoCurrencyPayload crypto_currency_payload
     5: MobileCommercePayload mobile_commerce_payload
+}
+
+struct GenericToolPayload {
+    1: required domain.GenericPaymentTool payment_tool
 }
 
 struct BankCardPayload {

--- a/proto/withdrawals_domain.thrift
+++ b/proto/withdrawals_domain.thrift
@@ -18,6 +18,7 @@ union Destination {
     1: domain.BankCard bank_card
     2: domain.CryptoWallet crypto_wallet
     3: domain.DigitalWallet digital_wallet
+    4: domain.GenericPaymentTool generic
 }
 
 struct Identity {

--- a/proto/withdrawals_provider_adapter.thrift
+++ b/proto/withdrawals_provider_adapter.thrift
@@ -96,7 +96,7 @@ struct Withdrawal {
     7: optional base.ID session_id
     2: required Cash body
     3: required Destination destination
-    7: optional PaymentMethodDefinition method
+    8: optional domain.PaymentMethodDefinition method
     4: optional Identity sender
     5: optional Identity receiver
     6: optional Quote quote

--- a/proto/withdrawals_provider_adapter.thrift
+++ b/proto/withdrawals_provider_adapter.thrift
@@ -96,6 +96,7 @@ struct Withdrawal {
     7: optional base.ID session_id
     2: required Cash body
     3: required Destination destination
+    7: optional PaymentMethodDefinition method
     4: optional Identity sender
     5: optional Identity receiver
     6: optional Quote quote

--- a/proto/withdrawals_provider_adapter.thrift
+++ b/proto/withdrawals_provider_adapter.thrift
@@ -96,7 +96,7 @@ struct Withdrawal {
     7: optional base.ID session_id
     2: required Cash body
     3: required Destination destination
-    8: optional domain.PaymentMethodDefinition method
+    8: optional domain.PaymentService payment_service
     4: optional Identity sender
     5: optional Identity receiver
     6: optional Quote quote


### PR DESCRIPTION
Попытка набросать модели, под которые при дальнейшем расширении можно будет запихнуть ненужную на этом уровне специфику: модели `PaymentTerminal`, `DigitalWallet` и `CryptoWallet`, и, что чуть сложнее, `MobileCommerce`. А теоретически и `BankCard`.

### DISCUSS

* Действительно ли эта специфика не нужна?

    Резолюция: на первый взгляд нет, но кажется сделаем себе хуже, если уберём вещи типа `DigitalWallet` / `CryptoCurrency` (которые в целом _понятные_ модели), потому что нам придётся учиться заново с ними работать в downstream-сервисах и на фронте.

* Категории методов оплаты?

   Резолюция: если у метода оплаты _может не быть_ своего провайдера, то категория нужна.

* Противоречия между желанием клиента понимать доступные методы оплаты и нашим желанием определять конкретный (как например в случае с мобильной коммерцией).  

* Адекватно ли задавать схемы таким образом? Неочевидно, как мы их будем версионировать.

    Резолюция: пока откладываем этот вопрос, понимать схемы нужно только платёжной форме.

* Есть ли смысл задавать inline-схемы? На первый взгляд может быть полезно для тестов. Но тогда непонятно, как на эту схему ссылаться в `base.Content.type`.

    Резолюция: пока откладываем этот вопрос, понимать схемы нужно только платёжной форме.
