### PR TITLE
APM-18: Reflect current `PaymentTerminal` @ merchstat

### DIFF
--- a/proto/merch_stat.thrift
+++ b/proto/merch_stat.thrift
@@ -169,7 +169,10 @@ enum CryptoCurrency {
 }
 
 struct PaymentTerminal {
-    1: required TerminalPaymentProvider terminal_type
+    2: optional domain.PaymentServiceRef payment_service
+
+    /** Deprecated */
+    1: optional TerminalPaymentProvider terminal_type_deprecated
 }
 
 enum TerminalPaymentProvider {


### PR DESCRIPTION
We already employ payment-service-only terminals in the wild.