### PR TITLE
APM-119 Add TextMessageDisplayRequest

### DIFF
--- a/proto/base.thrift
+++ b/proto/base.thrift
@@ -215,3 +215,11 @@ struct IntegerRange {
 /* Типы, используемые для идентфикации заявок */
 typedef i64 ClaimID
 typedef i32 ClaimRevision
+
+/**
+ * Язык разметки текста
+ */
+enum MarkupLanguage {
+    markdown
+    html
+}

--- a/proto/user_interaction.thrift
+++ b/proto/user_interaction.thrift
@@ -19,6 +19,13 @@ struct QrCode {
     1: required binary payload
 }
 
+struct TextMessage {
+    /** Содержимое сообщения */
+    1: required string payload
+    /** Язык разметки для интерпретации содержимого сообщения */
+    2: required base.MarkupLanguage markup_language
+}
+
 struct CryptoCash {
     1: required base.Rational crypto_amount
     2: required CryptoCurrencySymbolicCode crypto_symbolic_code
@@ -66,6 +73,10 @@ struct QrCodeDisplayRequest {
     1: required QrCode qr_code
 }
 
+struct TextMessageDisplayRequest {
+    1: required TextMessage text_message
+}
+
 union UserInteraction {
     /**
      * Требование переадресовать user agent пользователя, в виде HTTP-запроса.
@@ -91,4 +102,9 @@ union UserInteraction {
      * Запрос на отображение пользователю QR-кода
      */
     4: QrCodeDisplayRequest qr_code_display_request
+
+    /**
+     * Запрос на отображение пользователю текстового сообщения
+     */
+    5: TextMessageDisplayRequest text_message_display_request
 }


### PR DESCRIPTION
Как выяснилось, Dreftorpay предоставляет не NB, а P2P. Соответственно нам нужно отобразить плательщику "плашку" с кредами, на которые он должен перевести средства. 

По результатам обсуждения с Пашей и Ильдаром решили, что это удобно сделать через новый `userInteraction`. Адаптер на своей стороне формирует "плашку", которую должна отобразить форма. Договорились использовать для текста md-разметку. Опционально возможен html для более сложных страничек в будущем.

https://empayre.youtrack.cloud/issue/APM-13

![Screenshot 2022-04-12 at 11 48 05](https://user-images.githubusercontent.com/50321018/162967304-f01be822-adac-4b20-b052-e9d245d14314.png)