### PR TITLE
OPS-161: Revert legacy payment_system_is to `BankCardConditionDefinition`

### DIFF
--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -2586,36 +2586,12 @@ struct BankCardCondition {
     3: optional BankCardConditionDefinition definition
 }
 
-// deprecated completely never use
-enum LegacyBankCardPaymentSystem {
-    visa
-    mastercard
-    visaelectron
-    maestro
-    forbrugsforeningen
-    dankort
-    amex
-    dinersclub
-    discover
-    unionpay
-    jcb
-    nspkmir
-    elo
-    rupay
-    ebt
-    dummy  // Несуществующая платежная система для использования в непродовом окружении
-    uzcard
-}
-
 union BankCardConditionDefinition {
     2: BankRef issuer_bank_is
     3: PaymentSystemCondition payment_system
     4: Residence issuer_country_is
     5: bool empty_cvv_is
     6: BankCardCategoryRef category_is
-
-    // deprecated
-    1: LegacyBankCardPaymentSystem payment_system_is
 }
 
 struct PaymentSystemCondition {

--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -2592,6 +2592,9 @@ union BankCardConditionDefinition {
     4: Residence issuer_country_is
     5: bool empty_cvv_is
     6: BankCardCategoryRef category_is
+
+    // Reserved
+    // 1
 }
 
 struct PaymentSystemCondition {


### PR DESCRIPTION
(#50)

This reverts commit 09e7a7566819da21dfe9e7639857587537ccc64b.