### PR TITLE
TD-437: Revert "Allow to define more flexible conditions in terms"

### DIFF
--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -2376,7 +2376,6 @@ struct ProvisionTermSet {
 }
 
 struct PaymentsProvisionTerms {
-    11: optional Predicate allow
     1: optional CurrencySelector currencies
     2: optional CategorySelector categories
     3: optional PaymentMethodSelector payment_methods
@@ -2437,7 +2436,6 @@ struct WalletProvisionTerms {
 }
 
 struct WithdrawalProvisionTerms {
-    5: optional Predicate allow
     1: optional CurrencySelector currencies
     2: optional PayoutMethodSelector payout_methods
     3: optional CashLimitSelector cash_limit


### PR DESCRIPTION
This reverts commit dbb733fca1724d6f2ff82c4062e4f68046dc8759.