### PR TITLE
TD-810: Add dummy structs

### DIFF
--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -848,10 +848,14 @@ union Contractor {
     2: RegisteredUser registered_user
     1: LegalEntity legal_entity
     3: PrivateEntity private_entity
+    4: DummyEntity dummy_entity
 }
 
 struct RegisteredUser {
     1: required string email
+}
+
+struct DummyEntity {
 }
 
 union LegalEntity {
@@ -990,9 +994,13 @@ union PayoutToolInfo {
     2: InternationalBankAccount international_bank_account
     3: WalletInfo wallet_info
     4: PaymentInstitutionAccount payment_institution_account
+    5: DummyAccount dummy_account
 }
 
 struct PaymentInstitutionAccount {
+}
+
+struct DummyAccount {
 }
 
 typedef base.ID ContractID


### PR DESCRIPTION
При заведении магазина нет необходимости заполнять данные для Contractor и PayoutToolInfo. Добавил dummy структуры.