### PR TITLE
OPS-503: add chargeback category for internal use case

### DIFF
--- a/proto/domain.thrift
+++ b/proto/domain.thrift
@@ -686,12 +686,16 @@ union InvoicePaymentChargebackCategory {
        late presentment, credit processed as charge, invalid card numbers,
        addendum/“no show” disputes, incorrect charge amounts, and other similar situations. */
     4: InvoicePaymentChargebackCategoryProcessingError processing_error
+
+    /* Chargeback category that serves as a system category, for internal use. */
+    5: InvoicePaymentChargebackCategorySystemSet       system_set
 }
 
 struct InvoicePaymentChargebackCategoryFraud           {}
 struct InvoicePaymentChargebackCategoryDispute         {}
 struct InvoicePaymentChargebackCategoryAuthorisation   {}
 struct InvoicePaymentChargebackCategoryProcessingError {}
+struct InvoicePaymentChargebackCategorySystemSet       {}
 
 union InvoicePaymentChargebackStage {
     1: InvoicePaymentChargebackStageChargeback     chargeback


### PR DESCRIPTION
[OPS-503](https://empayre.youtrack.cloud/issue/OPS-503)

Системная категория чарджбеков, чтобы их можно было отделить от прочих, для внутреннего учета.