### PR TITLE
Adds CI tag action and bumps Erlang version in CI

### DIFF
--- a/.github/workflows/erlang-pr.yml
+++ b/.github/workflows/erlang-pr.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build:
-    uses: valitydev/erlang-workflows/.github/workflows/erlang-simple-build.yml@v1.0.16
+    uses: valitydev/erlang-workflows/.github/workflows/erlang-simple-build.yml@v1.0.18
     with:
-      otp-version: 24
-      rebar-version: 3.23
+      otp-version: 27
+      rebar-version: 3.24
       use-thrift: true
       thrift-version: 0.14.2.3
       run-eunit: false

--- a/.github/workflows/tag-action.yml
+++ b/.github/workflows/tag-action.yml
@@ -1,0 +1,18 @@
+name: Create Tag
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - uses: valitydev/action-tagger@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          with-v: true

--- a/rebar.config
+++ b/rebar.config
@@ -40,7 +40,6 @@
         % mandatory
         unmatched_returns,
         error_handling,
-        race_conditions,
         unknown
     ]},
     {plt_apps, all_deps}


### PR DESCRIPTION
Добавлен экшен позволяет автоматически увеличивать версию при вливке ПР.
Для управления уровнем увеличения версии см. https://github.com/valitydev/action-tagger?tab=readme-ov-file#more-advanced-usage

По-умолчанию бампает патч версию, что эквивалентно указанию где-либо в названии ПР ключевой строки `#patch`. Для минорных и мажорных изменений согласно semver, нужно указывать, соответственно, `#minor` или `#major`.